### PR TITLE
Adding Search Api Tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FAMS3 Integration
 
+The `SearchApi` takes a piece of information from a person and will execute a `search` against data providers.
+
 ## Note
 
 - Projects are to be based on .NET Core 2.2
@@ -31,6 +33,8 @@ Access Redis-Commander [here](http://localhost:8090) to access Redis data.
 
 You can interact with the search api using the following [Postman Collection](docs/BcGovSearchApi.postman_collection.json) and [Postman Environment](docs/BcGovApi.postman_environment.json)
 
+When a POST request is send to the people api, a message is send the the `InvestigatePerson` exchange
+
 ## Projects
 
 ### SearchAPI
@@ -48,3 +52,9 @@ _This is the  Scheduler Plugin_
 ### JobManager.Test
 
 _This is the test project for the  Scheduler Plugin_
+
+## Libs
+
+### SearchApi.Core
+
+This class lib project encapsulate reusable components accross search api applications.

--- a/app/FAMS3Integration.sln
+++ b/app/FAMS3Integration.sln
@@ -7,13 +7,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SearchAPI", "SearchAPI\Sear
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SearchAPI.Test", "SearchAPI.Test\SearchAPI.Test.csproj", "{0D5DFAE7-5BC4-4F74-B0B3-3C9720BEC714}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JobManager", "JobManager\JobManager.csproj", "{AFA2CC6F-EF2A-406E-8D3D-A551F90AC551}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JobManager", "JobManager\JobManager.csproj", "{AFA2CC6F-EF2A-406E-8D3D-A551F90AC551}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JobManager.Test", "JobManager.Test\JobManager.Test.csproj", "{A3FA1F9E-78CC-4843-84A1-CEF7CA520C5F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JobManager.Test", "JobManager.Test\JobManager.Test.csproj", "{A3FA1F9E-78CC-4843-84A1-CEF7CA520C5F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataModel", "DataModel\DataModel.csproj", "{AA0E0E2C-7B6D-4D03-B356-6442815E40A6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataModel", "DataModel\DataModel.csproj", "{AA0E0E2C-7B6D-4D03-B356-6442815E40A6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataModel.Test", "DataModel.Test\DataModel.Test.csproj", "{4F79A3F1-78AB-4173-85B4-F54CCFAD836D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataModel.Test", "DataModel.Test\DataModel.Test.csproj", "{4F79A3F1-78AB-4173-85B4-F54CCFAD836D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SearchApi.Core", "SearchApi.Core\SearchApi.Core.csproj", "{C7D31E97-C646-490A-BD5E-AE8BE056A1BB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SearchApi.Core.Test", "SearchApi.Core.Test\SearchApi.Core.Test.csproj", "{6926932C-E27C-4FDD-8D13-D93CE4CC0120}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,6 +49,14 @@ Global
 		{4F79A3F1-78AB-4173-85B4-F54CCFAD836D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4F79A3F1-78AB-4173-85B4-F54CCFAD836D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4F79A3F1-78AB-4173-85B4-F54CCFAD836D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7D31E97-C646-490A-BD5E-AE8BE056A1BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7D31E97-C646-490A-BD5E-AE8BE056A1BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7D31E97-C646-490A-BD5E-AE8BE056A1BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7D31E97-C646-490A-BD5E-AE8BE056A1BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6926932C-E27C-4FDD-8D13-D93CE4CC0120}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6926932C-E27C-4FDD-8D13-D93CE4CC0120}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6926932C-E27C-4FDD-8D13-D93CE4CC0120}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6926932C-E27C-4FDD-8D13-D93CE4CC0120}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/app/FAMS3Integration.sln
+++ b/app/FAMS3Integration.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SearchApi.Core", "SearchApi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SearchApi.Core.Test", "SearchApi.Core.Test\SearchApi.Core.Test.csproj", "{6926932C-E27C-4FDD-8D13-D93CE4CC0120}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SearchApi.Tracker", "SearchApi.Tracker\SearchApi.Tracker.csproj", "{0C0B8D97-5D44-4A43-8362-CFD28C10DB81}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{6926932C-E27C-4FDD-8D13-D93CE4CC0120}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6926932C-E27C-4FDD-8D13-D93CE4CC0120}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6926932C-E27C-4FDD-8D13-D93CE4CC0120}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C0B8D97-5D44-4A43-8362-CFD28C10DB81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C0B8D97-5D44-4A43-8362-CFD28C10DB81}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C0B8D97-5D44-4A43-8362-CFD28C10DB81}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C0B8D97-5D44-4A43-8362-CFD28C10DB81}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/app/SearchAPI/SearchAPI.csproj
+++ b/app/SearchAPI/SearchAPI.csproj
@@ -17,4 +17,8 @@
     <PackageReference Include="NSwag.AspNetCore" Version="13.1.2" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\SearchApi.Core\SearchApi.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/app/SearchAPI/Startup.cs
+++ b/app/SearchAPI/Startup.cs
@@ -13,8 +13,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using SearchApi.Core.Options;
 using SearchAPI.Models;
-using SearchAPI.Options;
 
 namespace SearchAPI
 {

--- a/app/SearchApi.Core.Test/Options/RabbitMqTest.cs
+++ b/app/SearchApi.Core.Test/Options/RabbitMqTest.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Http.Features;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using SearchApi.Core.Options;
 
 namespace SearchAPI.Test.Options

--- a/app/SearchApi.Core.Test/SearchApi.Core.Test.csproj
+++ b/app/SearchApi.Core.Test/SearchApi.Core.Test.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SearchApi.Core\SearchApi.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/app/SearchApi.Core/Options/RabbitMq.cs
+++ b/app/SearchApi.Core/Options/RabbitMq.cs
@@ -1,4 +1,4 @@
-﻿namespace SearchAPI.Options
+﻿namespace SearchApi.Core.Options
 {
     /// <summary>
     /// Represents the RabbitMq Configuration

--- a/app/SearchApi.Core/SearchApi.Core.csproj
+++ b/app/SearchApi.Core/SearchApi.Core.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/app/SearchApi.Tracker/Dockerfile
+++ b/app/SearchApi.Tracker/Dockerfile
@@ -1,0 +1,18 @@
+FROM mcr.microsoft.com/dotnet/core/runtime:2.2-stretch-slim AS base
+WORKDIR /app
+
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2-stretch AS build
+WORKDIR /src
+COPY ["SearchApi.Tracker.csproj", "SearchApi.Tracker/"]
+RUN dotnet restore "SearchApi.Tracker/SearchApi.Tracker.csproj"
+COPY . Search.ApiTracker/
+WORKDIR "/src/Search.ApiTracker"
+RUN dotnet build "SearchApi.Tracker.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "SearchApi.Tracker.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "SearchApi.Tracker.dll"]

--- a/app/SearchApi.Tracker/Program.cs
+++ b/app/SearchApi.Tracker/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace SearchApi.Tracker
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/app/SearchApi.Tracker/Properties/launchSettings.json
+++ b/app/SearchApi.Tracker/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "SearchApi.Tracker": {
+      "commandName": "Project"
+    },
+    "Docker": {
+      "commandName": "Docker"
+    }
+  }
+}

--- a/app/SearchApi.Tracker/SearchApi.Tracker.csproj
+++ b/app/SearchApi.Tracker/SearchApi.Tracker.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />
+  </ItemGroup>
+
+</Project>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,18 @@ services:
       - rabbitmq
       - redis
 
+  ####################### SEARCH TRACKER #########################################
+  search-tracker:
+    build: 
+      context: app/SearchApi.Tracker
+    restart:
+      always
+    networks:
+      - fams-integration
+    depends_on:
+      - rabbitmq
+      - redis
+
   ####################### RABBITMQ SERVER ######################################
   rabbitmq:
     image: rabbitmq:3.7.15-management


### PR DESCRIPTION
This PR includes the following proposed changed:

* new SearchApiTracker

The `SearchApiTracker` will handle `InvestigatePerson` requests and orchestrate the search across data providers